### PR TITLE
Add support for label editing

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,6 +189,8 @@
           <button id="clear-vertex-labels" class="label-control-btn">
             Clear Vertex Selection
           </button>
+          <input type="checkbox" id="change-vertex-labels">
+          <label for="change-face-labels"> Edit?</label><br>
         </div>
         <div id="vertex-label-list" class="label-list-common"></div>
       </div>
@@ -199,6 +201,8 @@
           <button id="clear-labels" class="label-control-btn">
             Clear Face Selection
           </button>
+          <input type="checkbox" id="change-face-labels">
+          <label for="change-face-labels"> Edit?</label><br>
         </div>
         <div id="label-list" class="label-list-common"></div>
       </div>

--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@
             Clear Vertex Selection
           </button>
           <input type="checkbox" id="change-vertex-labels">
-          <label for="change-face-labels"> Edit?</label><br>
+          <label for="change-vertex-labels"> Edit?</label><br>
         </div>
         <div id="vertex-label-list" class="label-list-common"></div>
       </div>

--- a/src/App.ts
+++ b/src/App.ts
@@ -626,6 +626,7 @@ export default class App {
     viewModeSelect.addEventListener("change", () => {
       this.updateModelListUI();
       this.updateExportButtonState();
+      this.updateLabelsEditBoxes();
     });
 
     this.exportModelButton.addEventListener("click", () =>
@@ -633,6 +634,24 @@ export default class App {
     );
     this.updateExportButtonState();
   }
+
+  updateLabelsEditBoxes() {
+    const viewModeSelect = document.getElementById("view-mode-select") as HTMLSelectElement;
+    const selectedMode = viewModeSelect.value;
+
+    const isNpcMode = selectedMode === "npcs";
+
+    if (this.changeVertexLabels) {
+      this.changeVertexLabels.disabled = isNpcMode;
+      this.changeVertexLabels.checked = isNpcMode ? false : this.changeVertexLabels.checked;
+    }
+
+    if (this.changeFaceLabels) {
+      this.changeFaceLabels.disabled = isNpcMode;
+      this.changeFaceLabels.checked = isNpcMode ? false : this.changeFaceLabels.checked;
+    }
+  }
+
 
   updateExportButtonState() {
     if (this.exportModelButton) {
@@ -670,10 +689,12 @@ export default class App {
         "change-face-labels"
     ) as HTMLInputElement;
     this.changeFaceLabels?.addEventListener("change", () => {
-    const selectedModel = this.viewer.getRenderer().selectedModel;
-    if (selectedModel) {
-      this.updateFaceLabelUI(selectedModel);
-    }})
+      const selectedModel = this.viewer.getRenderer().selectedModel;
+      if (selectedModel) {
+        this.updateFaceLabelUI(selectedModel);
+      }
+      this.updateLabelsEditBoxes();
+    })
   }
 
   initializeVertexLabelPanel() {
@@ -689,10 +710,12 @@ export default class App {
         "change-vertex-labels"
     ) as HTMLInputElement;
     this.changeVertexLabels?.addEventListener("change", () => {
-    const selectedModel = this.viewer.getRenderer().selectedModel;
-    if (selectedModel) {
-      this.updateVertexLabelUI(selectedModel);
-    }})
+      const selectedModel = this.viewer.getRenderer().selectedModel;
+      if (selectedModel) {
+        this.updateVertexLabelUI(selectedModel);
+      }
+      this.updateLabelsEditBoxes();
+    })
   }
 
   async updateModelListUI() {

--- a/src/App.ts
+++ b/src/App.ts
@@ -124,6 +124,8 @@ export default class App {
   modelSearchInput: HTMLInputElement;
   seqSearchInput: HTMLInputElement;
   exportModelButton: HTMLButtonElement | null;
+  changeFaceLabels: HTMLInputElement | null;
+  changeVertexLabels: HTMLInputElement | null;
 
   constructor() {
     this.container = document.getElementById("container");
@@ -151,6 +153,8 @@ export default class App {
     };
     this.currentSelectedAnimFrameInstance = null;
     this.loopSequenceCheckbox = null;
+    this.changeFaceLabels = null;
+    this.changeVertexLabels = null;
     this.modelSearchInput = document.getElementById(
       "model-search"
     ) as HTMLInputElement;
@@ -662,6 +666,14 @@ export default class App {
       '<div class="label-item no-labels"><span style="color: #888; font-style: italic;">No model loaded</span></div>';
     (document.getElementById("clear-labels") as HTMLButtonElement).disabled =
       true;
+    this.changeFaceLabels = document.getElementById(
+        "change-face-labels"
+    ) as HTMLInputElement;
+    this.changeFaceLabels?.addEventListener("change", () => {
+    const selectedModel = this.viewer.getRenderer().selectedModel;
+    if (selectedModel) {
+      this.updateFaceLabelUI(selectedModel);
+    }})
   }
 
   initializeVertexLabelPanel() {
@@ -673,6 +685,14 @@ export default class App {
     (
       document.getElementById("clear-vertex-labels") as HTMLButtonElement
     ).disabled = true;
+    this.changeVertexLabels = document.getElementById(
+        "change-vertex-labels"
+    ) as HTMLInputElement;
+    this.changeVertexLabels?.addEventListener("change", () => {
+    const selectedModel = this.viewer.getRenderer().selectedModel;
+    if (selectedModel) {
+      this.updateVertexLabelUI(selectedModel);
+    }})
   }
 
   async updateModelListUI() {
@@ -1077,6 +1097,85 @@ export default class App {
     }
   }
 
+  buildRemappedFaceArray(model: Model, map: Record<number, number>): Int32Array {
+    const out = new Int32Array(model.faceCount).fill(0);
+
+    if (model.labelFaces) {
+      model.labelFaces.forEach((faces, grp) => {
+        if (!faces) return;
+        const target = map[grp] ?? grp;
+        for (let i = 0; i < faces.length; i++) out[faces[i]] = target;
+      });
+    }
+
+    return out;
+  }
+
+  buildRemappedVertexArray(model: Model, map: Record<number, number>): Int32Array {
+    const out = new Int32Array(model.vertexCount).fill(0);
+
+    if (model.labelVertices) {
+      model.labelVertices.forEach((verts, grp) => {
+        if (!verts) return;
+        const target = map[grp] ?? grp;
+        for (let i = 0; i < verts.length; i++) out[verts[i]] = target;
+      });
+    }
+
+    return out;
+  }
+
+  applyCustomFaceLabels(model: Model) {
+    const mapping: Record<number, number> = {};
+    const labelItems = document.querySelectorAll("#label-list .label-item");
+
+    labelItems.forEach((item) => {
+      const labelText = item.querySelector("span")?.textContent;
+      const input = item.querySelector("input") as HTMLInputElement;
+
+      if (!labelText || !input) return;
+
+      const match = labelText.match(/Label\s+(\d+)/);
+      if (!match) return;
+
+      const originalId = parseInt(match[1]);
+      const newId = parseInt(input.value);
+
+      if (!isNaN(newId) && newId !== originalId) {
+        mapping[originalId] = newId;
+      }
+    });
+
+    model.faceLabelForExport = this.buildRemappedFaceArray(model, mapping);
+    model.hadOriginalFaceLabels = true;
+}
+
+
+  applyCustomVertexLabels(model: Model) {
+    const mapping: Record<number, number> = {};
+    const labelItems = document.querySelectorAll("#vertex-label-list .label-item");
+
+    labelItems.forEach((item) => {
+      const labelText = item.querySelector("span")?.textContent;
+      const input = item.querySelector("input") as HTMLInputElement;
+
+      if (!labelText || !input) return;
+
+      const match = labelText.match(/Label\s+(\d+)/);
+      if (!match) return;
+
+      const originalId = parseInt(match[1]);
+      const newId = parseInt(input.value);
+
+      if (!isNaN(newId) && newId !== originalId) {
+        mapping[originalId] = newId;
+      }
+    });
+
+    model.vertexLabelForExport = this.buildRemappedVertexArray(model, mapping);
+    model.hadOriginalVertexLabels = true;
+}
+
   async handleExportAnimFrame() {
     if (
       !this.currentSelectedAnimFrameInstance ||
@@ -1177,6 +1276,13 @@ export default class App {
       alert("Selected model instance not found.");
       this.updateExportButtonState();
       return;
+    }
+
+    if (this.changeFaceLabels?.checked && modelInstance) {
+      this.applyCustomFaceLabels(modelInstance);
+    }
+    if (this.changeVertexLabels?.checked && modelInstance) {
+      this.applyCustomVertexLabels(modelInstance);
     }
 
     try {
@@ -2416,7 +2522,26 @@ export default class App {
     labels.forEach((label) => {
       const item = document.createElement("div");
       item.className = "label-item";
-      item.innerHTML = `<span>Label ${label.id}</span><span class="label-count">${label.faceCount} faces</span>`;
+
+      const labelSpan = document.createElement("span");
+      labelSpan.textContent = `Label ${label.id}`;
+
+      const input = document.createElement("input");
+      input.type = "text";
+      input.value = label.id.toString(); // or leave blank if editable name
+      input.className = "label-edit-input";
+      input.style.marginLeft = "8px";
+      input.style.width = "40px";
+      input.disabled = !this.changeFaceLabels?.checked
+
+      const countSpan = document.createElement("span");
+      countSpan.className = "label-count";
+      countSpan.textContent = `${label.faceCount} faces`;
+
+      item.appendChild(labelSpan);
+      item.appendChild(input);
+      item.appendChild(countSpan);
+
       item.addEventListener("click", () => {
         document
           .querySelectorAll("#label-list .label-item")
@@ -2444,7 +2569,26 @@ export default class App {
     labels.forEach((label) => {
       const item = document.createElement("div");
       item.className = "label-item";
-      item.innerHTML = `<span>Label ${label.id}</span><span class="label-count">${label.vertexCount} vertices</span>`;
+
+      const labelSpan = document.createElement("span");
+      labelSpan.textContent = `Label ${label.id}`;
+
+      const input = document.createElement("input");
+      input.type = "text";
+      input.value = label.id.toString();
+      input.className = "label-edit-input";
+      input.style.marginLeft = "8px";
+      input.style.width = "40px";
+      input.disabled = !this.changeVertexLabels?.checked;
+
+      const countSpan = document.createElement("span");
+      countSpan.className = "label-count";
+      countSpan.textContent = `${label.vertexCount} vertices`;
+
+      item.appendChild(labelSpan);
+      item.appendChild(input);
+      item.appendChild(countSpan);
+
       item.addEventListener("click", () => {
         if (!this.viewer.getRenderer().editMode) {
           alert("Enable Vertex Editing mode to highlight vertex labels.");
@@ -2452,14 +2596,14 @@ export default class App {
         }
         document
           .querySelectorAll("#vertex-label-list .label-item")
-          .forEach((el) =>
-            el.classList.remove("selected", "highlighted-vertex")
-          );
+          .forEach((el) => el.classList.remove("selected", "highlighted-vertex"));
         item.classList.add("highlighted-vertex");
         this.viewer.getRenderer().highlightVertexLabel(label.id);
       });
+
       list.appendChild(item);
     });
+
   }
 
   updateVertexLabelUIState() {

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -198,8 +198,8 @@ export default class Model {
   private baseScaleX: number = 128;
   private baseScaleY: number = 128;
   private baseScaleZ: number = 128;
-  faceLabelForExport: Int32Array<ArrayBuffer> | undefined;
-  vertexLabelForExport: Int32Array<ArrayBuffer> | undefined;
+  faceLabelForExport: Int32Array | undefined;
+  vertexLabelForExport: Int32Array | undefined;
 
   constructor(type: ModelType) {
     this.vertexCount = type.vertexCount;

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -184,8 +184,8 @@ export default class Model {
   textureCoords: Int32Array;
   uvCoords: Float32Array2d;
 
-  private hadOriginalFaceLabels: boolean = false;
-  private hadOriginalVertexLabels: boolean = false;
+  hadOriginalFaceLabels: boolean = false;
+  hadOriginalVertexLabels: boolean = false;
   private hadOriginalFacePriorities: boolean = false;
   private hadOriginalFaceAlphas: boolean = false;
   private hadOriginalFaceInfos: boolean = false;
@@ -198,6 +198,8 @@ export default class Model {
   private baseScaleX: number = 128;
   private baseScaleY: number = 128;
   private baseScaleZ: number = 128;
+  faceLabelForExport: Int32Array<ArrayBuffer> | undefined;
+  vertexLabelForExport: Int32Array<ArrayBuffer> | undefined;
 
   constructor(type: ModelType) {
     this.vertexCount = type.vertexCount;
@@ -562,24 +564,30 @@ export default class Model {
     }
 
     if (this.hadOriginalFaceLabels) {
-      let actualFaceLabels: Uint8Array;
-      if (this.faceLabel) {
-        actualFaceLabels = Uint8Array.from(this.faceLabel);
+      let actualFaceLabels = new Uint8Array(this.faceCount).fill(0);
+
+      if ((this as any).faceLabelForExport instanceof Int32Array) {
+        const src = (this as any).faceLabelForExport as Int32Array;
+        console.log("Using faceLabelForExport in export:", src.slice(0, 20));
+        for (let i = 0; i < this.faceCount && i < src.length; i++) {
+          actualFaceLabels[i] = src[i];
+        }
       } else if (this.labelFaces) {
-        actualFaceLabels = new Uint8Array(this.faceCount).fill(0);
         for (let l = 0; l < this.labelFaces.length; l++) {
           const indices = this.labelFaces[l];
           if (indices) {
             for (let i = 0; i < indices.length; i++) {
-              if (indices[i] < this.faceCount) actualFaceLabels[indices[i]] = l;
+              if (indices[i] < this.faceCount) {
+                actualFaceLabels[indices[i]] = l;
+              }
             }
           }
         }
-      } else {
-        actualFaceLabels = new Uint8Array(this.faceCount).fill(0);
       }
+
       dataBlocks.push(actualFaceLabels);
     }
+
 
     if (this.hadOriginalFaceInfos) {
       const faceInfosData = this.faceInfo
@@ -589,25 +597,29 @@ export default class Model {
     }
 
     if (this.hadOriginalVertexLabels) {
-      let actualVertexLabels: Uint8Array;
-      if (this.vertexLabel) {
-        actualVertexLabels = Uint8Array.from(this.vertexLabel);
+      let actualVertexLabels = new Uint8Array(this.vertexCount).fill(0);
+
+      if ((this as any).vertexLabelForExport instanceof Int32Array) {
+        const src = (this as any).vertexLabelForExport as Int32Array;
+        for (let i = 0; i < this.vertexCount && i < src.length; i++) {
+          actualVertexLabels[i] = src[i];
+        }
       } else if (this.labelVertices) {
-        actualVertexLabels = new Uint8Array(this.vertexCount).fill(0);
         for (let l = 0; l < this.labelVertices.length; l++) {
           const indices = this.labelVertices[l];
           if (indices) {
             for (let i = 0; i < indices.length; i++) {
-              if (indices[i] < this.vertexCount)
+              if (indices[i] < this.vertexCount) {
                 actualVertexLabels[indices[i]] = l;
+              }
             }
           }
         }
-      } else {
-        actualVertexLabels = new Uint8Array(this.vertexCount).fill(0);
       }
+
       dataBlocks.push(actualVertexLabels);
     }
+
 
     if (this.hadOriginalFaceAlphas) {
       const faceAlphasData = this.faceAlpha


### PR DESCRIPTION
Currently you can't change labels on the website.
Older models use different labeling system, hence not working correctly with animations.

Added support for changing labels, so you can export models with correct labels.

Affected areas: index.html, app.ts, Model.ts

Hand tested, no irregularities were found
![image](https://github.com/user-attachments/assets/03549923-347e-44d5-ae20-de4d7dc95058)
